### PR TITLE
[Park] Store 분리 + 최근검색어 이벤트

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "pwa-chrome",
+            "request": "launch",
+            "name": "Launch Chrome against localhost",
+            "url": "http://localhost:8080",
+            "webRoot": "${workspaceFolder}"
+        }
+    ]
+}

--- a/src/client/js/App.js
+++ b/src/client/js/App.js
@@ -13,10 +13,12 @@ App.prototype.mount = function () {
   const $body = this.$target.querySelector(".body");
   const header = new Header($header);
   const body = new Body($body);
+
   [header, body].forEach((component) => {
     component.initRender();
   });
 };
+
 App.prototype.template = function () {
   return `
     <div class="header"></div>

--- a/src/client/js/Store.js
+++ b/src/client/js/Store.js
@@ -3,12 +3,12 @@ import { observable } from "./core/observer";
 const initState = {
   categoryTitle: "전체",
   categoryDatas: [],
+  searchWord: "",
   searchRecentDisplay: "none",
   searchSuggestionDisplay: "none",
-  selectedInputIdx: 0,
   suggestionDatas: [],
   recentDatas: JSON.parse(localStorage.getItem("recent")) || [],
-  searchWord: "",
+  selectedInputIdx: 0,
 };
 
 export const store = {

--- a/src/client/js/Store.js
+++ b/src/client/js/Store.js
@@ -11,7 +11,7 @@ const initState = {
   selectedInputIdx: 0,
 };
 
-export const store = {
+const store = {
   state: observable(initState),
   setState(newState) {
     Object.entries(newState).forEach(([key, value]) => {
@@ -19,3 +19,5 @@ export const store = {
     });
   },
 };
+
+export { store };

--- a/src/client/js/Store.js
+++ b/src/client/js/Store.js
@@ -7,6 +7,7 @@ const initState = {
   searchSuggestionDisplay: "none",
   selectedInputIdx: 0,
   suggestionDatas: [],
+  recentDatas: JSON.parse(localStorage.getItem("recent")) || [],
   searchWord: "",
 };
 

--- a/src/client/js/Store.js
+++ b/src/client/js/Store.js
@@ -1,4 +1,4 @@
-import { observable } from "./observer";
+import { observable } from "./core/observer";
 
 const initState = {
   categoryTitle: "전체",

--- a/src/client/js/components/Body/Body.js
+++ b/src/client/js/components/Body/Body.js
@@ -1,23 +1,14 @@
 import Component from "../../core/Component";
 import { createExtendsRelation } from "../../oop-utils";
-import { store } from "../../core/Store";
 
 function Body(...params) {
   Component.call(this, ...params);
 }
 createExtendsRelation(Body, Component);
 
-Body.prototype.setEvent = function () {
-  this.addEvent("click", ".increaseBtn", ({ target }) => {
-    const { a } = store.state;
-    store.setState({ a: a + 1, b: 2 });
-  });
-};
 Body.prototype.template = function () {
-  const { a } = store.state;
   return `
-    <div>Hello body${a}${store.state.b}</div>
-    <button class="increaseBtn">증가</button>
+    <div>Hello body</div>
   `;
 };
 

--- a/src/client/js/components/Body/Body.js
+++ b/src/client/js/components/Body/Body.js
@@ -1,13 +1,24 @@
 import Component from "../../core/Component";
 import { createExtendsRelation } from "../../oop-utils";
+import { store } from "../../core/Store";
 
 function Body(...params) {
   Component.call(this, ...params);
 }
 createExtendsRelation(Body, Component);
 
+Body.prototype.setEvent = function () {
+  this.addEvent("click", ".increaseBtn", ({ target }) => {
+    const { a } = store.state;
+    store.setState({ a: a + 1, b: 2 });
+  });
+};
 Body.prototype.template = function () {
-  return `<div>Hello body</div>`;
+  const { a } = store.state;
+  return `
+    <div>Hello body${a}${store.state.b}</div>
+    <button class="increaseBtn">증가</button>
+  `;
 };
 
 export default Body;

--- a/src/client/js/components/Header/Search/Search.js
+++ b/src/client/js/components/Header/Search/Search.js
@@ -10,7 +10,7 @@ import {
   handleBodyClick,
   handleSearchCategoryClick,
 } from "./controllers/search";
-import { store } from "../../../core/Store";
+import { store } from "../../../Store";
 
 function Search(...params) {
   Component.call(this, ...params);

--- a/src/client/js/components/Header/Search/Search.js
+++ b/src/client/js/components/Header/Search/Search.js
@@ -20,6 +20,16 @@ createExtendsRelation(Search, Component);
 Search.prototype.setEvent = function () {
   document.body.addEventListener("click", handleBodyClick);
   this.addEvent("click", ".search__category", handleSearchCategoryClick);
+  this.addEvent("transitionstart", ".search__category-list", ({ target }) => {
+    target.style.boxShadow = "0 4px 5px rgb(0 0 0 / 30%)";
+    target.style.border = "1px #d1d8e0 solid";
+  });
+  this.addEvent("transitionend", ".search__category-list", ({ target }) => {
+    if (!target.classList.contains("list-act")) {
+      target.style.boxShadow = "none";
+      target.style.border = "none";
+    }
+  });
 };
 
 Search.prototype.mount = async function () {

--- a/src/client/js/components/Header/Search/Search.js
+++ b/src/client/js/components/Header/Search/Search.js
@@ -9,8 +9,10 @@ import SearchSuggestion from "./SearchUI/SearchSuggestion";
 import {
   handleBodyClick,
   handleSearchCategoryClick,
+  handleCListTransStart,
+  handleCListTransEnd,
 } from "./controllers/search";
-import { store } from "../../../Store";
+import { store } from "../../../store";
 
 function Search(...params) {
   Component.call(this, ...params);
@@ -20,16 +22,12 @@ createExtendsRelation(Search, Component);
 Search.prototype.setEvent = function () {
   document.body.addEventListener("click", handleBodyClick);
   this.addEvent("click", ".search__category", handleSearchCategoryClick);
-  this.addEvent("transitionstart", ".search__category-list", ({ target }) => {
-    target.style.boxShadow = "0 4px 5px rgb(0 0 0 / 30%)";
-    target.style.border = "1px #d1d8e0 solid";
-  });
-  this.addEvent("transitionend", ".search__category-list", ({ target }) => {
-    if (!target.classList.contains("list-act")) {
-      target.style.boxShadow = "none";
-      target.style.border = "none";
-    }
-  });
+  this.addEvent(
+    "transitionstart",
+    ".search__category-list",
+    handleCListTransStart
+  );
+  this.addEvent("transitionend", ".search__category-list", handleCListTransEnd);
 };
 
 Search.prototype.mount = async function () {
@@ -49,6 +47,7 @@ Search.prototype.mount = async function () {
   const searchRecent = new SearchRecent($searchRecent);
   const searchSuggestion = new SearchSuggestion($searchSuggestion);
   const searchInput = new SearchInput($searchInput);
+
   [
     searchCategory,
     searchCategoryList,

--- a/src/client/js/components/Header/Search/Search.js
+++ b/src/client/js/components/Header/Search/Search.js
@@ -12,7 +12,7 @@ import {
   handleCListTransStart,
   handleCListTransEnd,
 } from "./controllers/search";
-import { store } from "../../../store";
+import { store } from "../../../Store";
 
 function Search(...params) {
   Component.call(this, ...params);

--- a/src/client/js/components/Header/Search/Search.js
+++ b/src/client/js/components/Header/Search/Search.js
@@ -10,6 +10,7 @@ import {
   handleBodyClick,
   handleSearchCategoryClick,
 } from "./controllers/search";
+import { store } from "../../../core/Store";
 
 function Search(...params) {
   Component.call(this, ...params);
@@ -17,13 +18,10 @@ function Search(...params) {
 createExtendsRelation(Search, Component);
 
 Search.prototype.setEvent = function () {
-  document.body.addEventListener("click", handleBodyClick.bind(this));
-  this.addEvent(
-    "click",
-    ".search__category",
-    handleSearchCategoryClick.bind(this)
-  );
+  document.body.addEventListener("click", handleBodyClick);
+  this.addEvent("click", ".search__category", handleSearchCategoryClick);
 };
+
 Search.prototype.mount = async function () {
   const $searchCategory = this.$target.querySelector(".search__category");
   const $searchCategoryList = this.$target.querySelector(
@@ -33,19 +31,14 @@ Search.prototype.mount = async function () {
   const $searchRecent = this.$target.querySelector(".search__recent");
   const $searchSuggestion = this.$target.querySelector(".search__suggestion");
 
-  const { results: categoryData } = await request("search/category");
+  const { results: categoryDatas } = await request("search/category");
+  store.setState({ categoryDatas });
 
   const searchCategory = new SearchCategory($searchCategory);
-  const searchCategoryList = new SearchCategoryList($searchCategoryList, {
-    categoryData,
-    searchCategory,
-  });
+  const searchCategoryList = new SearchCategoryList($searchCategoryList);
   const searchRecent = new SearchRecent($searchRecent);
   const searchSuggestion = new SearchSuggestion($searchSuggestion);
-  const searchInput = new SearchInput($searchInput, {
-    searchSuggestion,
-    searchRecent,
-  });
+  const searchInput = new SearchInput($searchInput);
   [
     searchCategory,
     searchCategoryList,
@@ -55,14 +48,6 @@ Search.prototype.mount = async function () {
   ].forEach((component) => {
     component.initRender();
   });
-
-  this.state = {
-    searchCategory,
-    searchCategoryList,
-    searchRecent,
-    searchSuggestion,
-    searchInput,
-  };
 };
 
 Search.prototype.template = function () {

--- a/src/client/js/components/Header/Search/SearchUI/SearchCategory.js
+++ b/src/client/js/components/Header/Search/SearchUI/SearchCategory.js
@@ -1,5 +1,5 @@
 import Component from "../../../../core/Component";
-import { store } from "../../../../Store";
+import { store } from "../../../../store";
 import { createExtendsRelation } from "../../../../oop-utils";
 
 function SearchCategory(...params) {

--- a/src/client/js/components/Header/Search/SearchUI/SearchCategory.js
+++ b/src/client/js/components/Header/Search/SearchUI/SearchCategory.js
@@ -1,5 +1,5 @@
 import Component from "../../../../core/Component";
-import { store } from "../../../../store";
+import { store } from "../../../../Store";
 import { createExtendsRelation } from "../../../../oop-utils";
 
 function SearchCategory(...params) {

--- a/src/client/js/components/Header/Search/SearchUI/SearchCategory.js
+++ b/src/client/js/components/Header/Search/SearchUI/SearchCategory.js
@@ -1,5 +1,5 @@
 import Component from "../../../../core/Component";
-import { store } from "../../../../core/Store";
+import { store } from "../../../../Store";
 import { createExtendsRelation } from "../../../../oop-utils";
 
 function SearchCategory(...params) {

--- a/src/client/js/components/Header/Search/SearchUI/SearchCategory.js
+++ b/src/client/js/components/Header/Search/SearchUI/SearchCategory.js
@@ -1,19 +1,15 @@
 import Component from "../../../../core/Component";
+import { store } from "../../../../core/Store";
 import { createExtendsRelation } from "../../../../oop-utils";
 
 function SearchCategory(...params) {
   Component.call(this, ...params);
 }
+
 createExtendsRelation(SearchCategory, Component);
 
-SearchCategory.prototype.setup = function () {
-  this.state = {
-    categoryTitle: "전체",
-  };
-};
 SearchCategory.prototype.template = function () {
-  const { categoryTitle } = this.state;
-
+  const { categoryTitle } = store.state;
   return `
     <span class="category__title">${categoryTitle}</span>
     <span class="category__arrow">▼</span>

--- a/src/client/js/components/Header/Search/SearchUI/SearchCategoryList.js
+++ b/src/client/js/components/Header/Search/SearchUI/SearchCategoryList.js
@@ -1,5 +1,5 @@
 import Component from "../../../../core/Component";
-import { store } from "../../../../core/Store";
+import { store } from "../../../../Store";
 import { createExtendsRelation } from "../../../../oop-utils";
 
 function SearchCategoryList(...params) {

--- a/src/client/js/components/Header/Search/SearchUI/SearchCategoryList.js
+++ b/src/client/js/components/Header/Search/SearchUI/SearchCategoryList.js
@@ -1,5 +1,5 @@
 import Component from "../../../../core/Component";
-import { store } from "../../../../Store";
+import { store } from "../../../../store";
 import { createExtendsRelation } from "../../../../oop-utils";
 
 function SearchCategoryList(...params) {

--- a/src/client/js/components/Header/Search/SearchUI/SearchCategoryList.js
+++ b/src/client/js/components/Header/Search/SearchUI/SearchCategoryList.js
@@ -1,5 +1,5 @@
 import Component from "../../../../core/Component";
-import { store } from "../../../../store";
+import { store } from "../../../../Store";
 import { createExtendsRelation } from "../../../../oop-utils";
 
 function SearchCategoryList(...params) {

--- a/src/client/js/components/Header/Search/SearchUI/SearchCategoryList.js
+++ b/src/client/js/components/Header/Search/SearchUI/SearchCategoryList.js
@@ -1,4 +1,5 @@
 import Component from "../../../../core/Component";
+import { store } from "../../../../core/Store";
 import { createExtendsRelation } from "../../../../oop-utils";
 
 function SearchCategoryList(...params) {
@@ -7,14 +8,14 @@ function SearchCategoryList(...params) {
 createExtendsRelation(SearchCategoryList, Component);
 
 SearchCategoryList.prototype.setEvent = function () {
-  const { searchCategory } = this.$props;
   this.addEvent("click", "li", ({ target }) => {
-    searchCategory.setState({ categoryTitle: target.textContent });
+    store.setState({ categoryTitle: target.textContent });
   });
 };
+
 SearchCategoryList.prototype.template = function () {
-  const { categoryData } = this.$props;
-  return categoryData.map((data) => `<li>${data}</li>`).join("");
+  const { categoryDatas } = store.state;
+  return categoryDatas.map((data) => `<li>${data}</li>`).join("");
 };
 
 export default SearchCategoryList;

--- a/src/client/js/components/Header/Search/SearchUI/SearchInput.js
+++ b/src/client/js/components/Header/Search/SearchUI/SearchInput.js
@@ -1,7 +1,6 @@
 import Component from "../../../../core/Component";
 import { createExtendsRelation } from "../../../../oop-utils";
 import {
-  handleArrowKeydown,
   handleInputFocusIn,
   handleInputFocusOut,
   handleKeyupWithFocus,
@@ -16,7 +15,6 @@ SearchInput.prototype.setEvent = function () {
   this.addEvent("focusout", "input[type='text']", handleInputFocusOut);
   this.addEvent("focusin", "input[type='text']", handleInputFocusIn);
   this.addEvent("keyup", "input[type='text']", handleKeyupWithFocus);
-  this.addEvent("keydown", "input[type='text']", handleArrowKeydown);
 };
 
 SearchInput.prototype.template = function () {

--- a/src/client/js/components/Header/Search/SearchUI/SearchInput.js
+++ b/src/client/js/components/Header/Search/SearchUI/SearchInput.js
@@ -12,27 +12,16 @@ function SearchInput(...params) {
 }
 createExtendsRelation(SearchInput, Component);
 
-SearchInput.prototype.setup = function () {
-  this.state = {
-    inputData: "",
-  };
-};
-
 SearchInput.prototype.setEvent = function () {
-  this.addEvent(
-    "focusout",
-    "input[type='text']",
-    handleInputFocusOut.bind(this)
-  );
-  this.addEvent("focusin", "input[type='text']", handleInputFocusIn.bind(this));
-  this.addEvent("keyup", "input[type='text']", handleKeyupWithFocus.bind(this));
-  this.addEvent("keydown", "input[type='text']", handleArrowKeydown.bind(this));
+  this.addEvent("focusout", "input[type='text']", handleInputFocusOut);
+  this.addEvent("focusin", "input[type='text']", handleInputFocusIn);
+  this.addEvent("keyup", "input[type='text']", handleKeyupWithFocus);
+  this.addEvent("keydown", "input[type='text']", handleArrowKeydown);
 };
 
 SearchInput.prototype.template = function () {
-  const { inputData } = this.state;
   return `
-    <input type="text" placeholder="찾고 싶은 상품을 검색해보세요!" value="${inputData}"/>
+    <input type="text" placeholder="찾고 싶은 상품을 검색해보세요!"/>
     <span class="input__icon">
         <i class="fas fa-microphone"></i>
     </span>

--- a/src/client/js/components/Header/Search/SearchUI/SearchInput.js
+++ b/src/client/js/components/Header/Search/SearchUI/SearchInput.js
@@ -4,6 +4,7 @@ import {
   handleInputFocusIn,
   handleInputFocusOut,
   handleKeyupWithFocus,
+  handleSearchIconClick,
 } from "../controllers/searchInput";
 
 function SearchInput(...params) {
@@ -15,6 +16,7 @@ SearchInput.prototype.setEvent = function () {
   this.addEvent("focusout", "input[type='text']", handleInputFocusOut);
   this.addEvent("focusin", "input[type='text']", handleInputFocusIn);
   this.addEvent("keyup", "input[type='text']", handleKeyupWithFocus);
+  this.addEvent("click", ".fa-search", handleSearchIconClick);
 };
 
 SearchInput.prototype.template = function () {

--- a/src/client/js/components/Header/Search/SearchUI/SearchRecent.js
+++ b/src/client/js/components/Header/Search/SearchUI/SearchRecent.js
@@ -1,21 +1,15 @@
 import Component from "../../../../core/Component";
 import { createExtendsRelation } from "../../../../oop-utils";
+import { store } from "../../../../core/Store";
 
 function SearchRecent(...params) {
   Component.call(this, ...params);
 }
 createExtendsRelation(SearchRecent, Component);
 
-SearchRecent.prototype.setup = function () {
-  this.state = {
-    display: "none",
-    selectedIndex: 0,
-  };
-};
-
 SearchRecent.prototype.mount = function () {
-  const { display } = this.state;
-  this.$target.style.display = display;
+  const { searchRecentDisplay } = store.state;
+  this.$target.style.display = searchRecentDisplay;
 };
 
 SearchRecent.prototype.template = function () {

--- a/src/client/js/components/Header/Search/SearchUI/SearchRecent.js
+++ b/src/client/js/components/Header/Search/SearchUI/SearchRecent.js
@@ -1,6 +1,6 @@
 import Component from "../../../../core/Component";
 import { createExtendsRelation } from "../../../../oop-utils";
-import { store } from "../../../../Store";
+import { store } from "../../../../store";
 
 function SearchRecent(...params) {
   Component.call(this, ...params);
@@ -14,19 +14,19 @@ SearchRecent.prototype.mount = function () {
 
 SearchRecent.prototype.template = function () {
   const { recentDatas, selectedInputIdx } = store.state;
+  const isSelectedIdx = (idx) =>
+    idx + 1 === selectedInputIdx ? "class='selected'" : "";
+
+  const recents = recentDatas
+    ?.map((data, idx) => `<span ${isSelectedIdx(idx)}>${data}</span>`)
+    .join("");
+
   return `
     <div class="recent__title">
         <span>최근 검색어</span>
     </div>
     <div class="recent__body">
-        ${recentDatas
-          ?.map(
-            (data, idx) =>
-              `<span ${
-                idx + 1 === selectedInputIdx ? "class='selected'" : ""
-              }>${data}</span>`
-          )
-          .join("")}
+        ${recents || `<span>최근 검색어가 없습니다.</span>`}
     </div>
     <div class="recent__footer">
         <span class="recent__deleteBtn">전체삭제</span>

--- a/src/client/js/components/Header/Search/SearchUI/SearchRecent.js
+++ b/src/client/js/components/Header/Search/SearchUI/SearchRecent.js
@@ -1,6 +1,6 @@
 import Component from "../../../../core/Component";
 import { createExtendsRelation } from "../../../../oop-utils";
-import { store } from "../../../../store";
+import { store } from "../../../../Store";
 
 function SearchRecent(...params) {
   Component.call(this, ...params);

--- a/src/client/js/components/Header/Search/SearchUI/SearchRecent.js
+++ b/src/client/js/components/Header/Search/SearchUI/SearchRecent.js
@@ -13,13 +13,20 @@ SearchRecent.prototype.mount = function () {
 };
 
 SearchRecent.prototype.template = function () {
+  const { recentDatas, selectedInputIdx } = store.state;
   return `
     <div class="recent__title">
         <span>최근 검색어</span>
     </div>
     <div class="recent__body">
-        <span>코드스쿼드</span>
-        <span>아이폰</span>
+        ${recentDatas
+          ?.map(
+            (data, idx) =>
+              `<span ${
+                idx + 1 === selectedInputIdx ? "class='selected'" : ""
+              }>${data}</span>`
+          )
+          .join("")}
     </div>
     <div class="recent__footer">
         <span class="recent__deleteBtn">전체삭제</span>

--- a/src/client/js/components/Header/Search/SearchUI/SearchRecent.js
+++ b/src/client/js/components/Header/Search/SearchUI/SearchRecent.js
@@ -1,6 +1,6 @@
 import Component from "../../../../core/Component";
 import { createExtendsRelation } from "../../../../oop-utils";
-import { store } from "../../../../core/Store";
+import { store } from "../../../../Store";
 
 function SearchRecent(...params) {
   Component.call(this, ...params);

--- a/src/client/js/components/Header/Search/SearchUI/SearchSuggestion.js
+++ b/src/client/js/components/Header/Search/SearchUI/SearchSuggestion.js
@@ -8,8 +8,10 @@ function SearchSuggestion(...params) {
 createExtendsRelation(SearchSuggestion, Component);
 
 const highlightWord = (string, word) => {
-  const regex = new RegExp(`(?<front>.+)?(?<matchedWord>${word})(?<back>.+)?`);
-  const { groups } = string.match(regex) || { groups: {} };
+  const matchedWordRegex = new RegExp(
+    `(?<front>.+)?(?<matchedWord>${word})(?<back>.+)?`
+  );
+  const { groups } = string.match(matchedWordRegex) || { groups: {} };
   const { front, matchedWord, back } = groups;
 
   return matchedWord

--- a/src/client/js/components/Header/Search/SearchUI/SearchSuggestion.js
+++ b/src/client/js/components/Header/Search/SearchUI/SearchSuggestion.js
@@ -1,6 +1,6 @@
 import Component from "../../../../core/Component";
 import { createExtendsRelation } from "../../../../oop-utils";
-import { store } from "../../../../core/Store";
+import { store } from "../../../../Store";
 
 function SearchSuggestion(...params) {
   Component.call(this, ...params);

--- a/src/client/js/components/Header/Search/SearchUI/SearchSuggestion.js
+++ b/src/client/js/components/Header/Search/SearchUI/SearchSuggestion.js
@@ -1,6 +1,6 @@
 import Component from "../../../../core/Component";
 import { createExtendsRelation } from "../../../../oop-utils";
-import { store } from "../../../../store";
+import { store } from "../../../../Store";
 import { highlightWord } from "../controllers/searchSuggestion";
 
 function SearchSuggestion(...params) {

--- a/src/client/js/components/Header/Search/SearchUI/SearchSuggestion.js
+++ b/src/client/js/components/Header/Search/SearchUI/SearchSuggestion.js
@@ -1,31 +1,12 @@
 import Component from "../../../../core/Component";
 import { createExtendsRelation } from "../../../../oop-utils";
-import { store } from "../../../../Store";
+import { store } from "../../../../store";
+import { highlightWord } from "../controllers/searchSuggestion";
 
 function SearchSuggestion(...params) {
   Component.call(this, ...params);
 }
 createExtendsRelation(SearchSuggestion, Component);
-
-const highlightWord = (string, word) => {
-  const matchedWordRegex = new RegExp(
-    `(?<front>.+)?(?<matchedWord>${word})(?<back>.+)?`
-  );
-  const { groups } = string.match(matchedWordRegex) || { groups: {} };
-  const { front, matchedWord, back } = groups;
-
-  return matchedWord
-    ? `${front || ""}<span class="matchedWord">${matchedWord}</span>${
-        back || ""
-      }`
-    : string;
-};
-
-SearchSuggestion.prototype.getSelectedData = function () {
-  const $suggestionBody = this.$target.querySelector(".suggestion__body");
-  const $selected = $suggestionBody.querySelector(".selected");
-  return $selected ? $selected.textContent : null;
-};
 
 SearchSuggestion.prototype.mount = function () {
   const { searchSuggestionDisplay } = store.state;
@@ -34,19 +15,22 @@ SearchSuggestion.prototype.mount = function () {
 
 SearchSuggestion.prototype.template = function () {
   const { suggestionDatas, searchWord, selectedInputIdx } = store.state;
+  const isSelectedIdx = (idx) =>
+    idx + 1 === selectedInputIdx ? "class='selected'" : "";
+
   const suggestions = suggestionDatas
-    ? suggestionDatas
-        .map(
-          ({ keyword }, idx) =>
-            `<span ${
-              idx + 1 === selectedInputIdx ? "class='selected'" : ""
-            }>${highlightWord(keyword, searchWord)}</span>`
-        )
-        .join("")
-    : "";
+    ?.map(
+      ({ keyword }, idx) =>
+        `<span ${isSelectedIdx(idx)}>${highlightWord(
+          keyword,
+          searchWord
+        )}</span>`
+    )
+    .join("");
+
   return `
     <div class="suggestion__body">
-        ${suggestions}
+        ${suggestions || ""}
     </div>
   `;
 };

--- a/src/client/js/components/Header/Search/SearchUI/SearchSuggestion.js
+++ b/src/client/js/components/Header/Search/SearchUI/SearchSuggestion.js
@@ -1,5 +1,6 @@
 import Component from "../../../../core/Component";
 import { createExtendsRelation } from "../../../../oop-utils";
+import { store } from "../../../../core/Store";
 
 function SearchSuggestion(...params) {
   Component.call(this, ...params);
@@ -18,15 +19,6 @@ const highlightWord = (string, word) => {
     : string;
 };
 
-SearchSuggestion.prototype.setup = function () {
-  this.state = {
-    selectedIndex: 0,
-    suggestionDatas: [],
-    word: "",
-    display: "none",
-  };
-};
-
 SearchSuggestion.prototype.getSelectedData = function () {
   const $suggestionBody = this.$target.querySelector(".suggestion__body");
   const $selected = $suggestionBody.querySelector(".selected");
@@ -34,19 +26,19 @@ SearchSuggestion.prototype.getSelectedData = function () {
 };
 
 SearchSuggestion.prototype.mount = function () {
-  const { display } = this.state;
-  this.$target.style.display = display;
+  const { searchSuggestionDisplay } = store.state;
+  this.$target.style.display = searchSuggestionDisplay;
 };
 
 SearchSuggestion.prototype.template = function () {
-  const { suggestionDatas, word, selectedIndex } = this.state;
+  const { suggestionDatas, searchWord, selectedInputIdx } = store.state;
   const suggestions = suggestionDatas
     ? suggestionDatas
         .map(
           ({ keyword }, idx) =>
             `<span ${
-              idx + 1 === selectedIndex ? "class='selected'" : ""
-            }>${highlightWord(keyword, word)}</span>`
+              idx + 1 === selectedInputIdx ? "class='selected'" : ""
+            }>${highlightWord(keyword, searchWord)}</span>`
         )
         .join("")
     : "";

--- a/src/client/js/components/Header/Search/controllers/search.js
+++ b/src/client/js/components/Header/Search/controllers/search.js
@@ -23,4 +23,21 @@ const handleSearchCategoryClick = ({ target }) => {
   $searchCategoryList.classList.toggle("list-act");
 };
 
-export { handleBodyClick, handleSearchCategoryClick };
+const handleCListTransStart = ({ target }) => {
+  target.style.boxShadow = "0 4px 5px rgb(0 0 0 / 30%)";
+  target.style.border = "1px #d1d8e0 solid";
+};
+
+const handleCListTransEnd = ({ target }) => {
+  if (!target.classList.contains("list-act")) {
+    target.style.boxShadow = "none";
+    target.style.border = "none";
+  }
+};
+
+export {
+  handleBodyClick,
+  handleSearchCategoryClick,
+  handleCListTransStart,
+  handleCListTransEnd,
+};

--- a/src/client/js/components/Header/Search/controllers/search.js
+++ b/src/client/js/components/Header/Search/controllers/search.js
@@ -1,46 +1,26 @@
-import { delay } from "../../../../utils";
-
-const delayVisible = async (ms, lists) => {
-  for (const li of lists) {
-    await delay(ms);
-    li.style.visibility =
-      li.style.visibility === "visible" ? "hidden" : "visible";
-  }
-};
-
-async function handleBodyClick({ target }) {
-  const $searchCategoryList = this.$target.querySelector(
+const handleBodyClick = ({ target }) => {
+  const $searchCategoryList = document.body.querySelector(
     ".search__category-list"
   );
   const $target = target.closest(".search__category");
-  const $searchCategory = this.$target.querySelector(".search__category");
-  const TARGET_IS_SCATEGORY = $target === $searchCategory;
-  const CATEGORY_LIST_ACTING =
+  const $searchCategory = document.body.querySelector(".search__category");
+
+  const isSearchCategory = $target === $searchCategory;
+  const isActingCategoryList =
     $searchCategoryList.classList.contains("list-act");
-  const CLICK_OTHER_BODY = !TARGET_IS_SCATEGORY && CATEGORY_LIST_ACTING;
+  const isClickOtherBody = !isSearchCategory && isActingCategoryList;
 
-  if (CLICK_OTHER_BODY) {
+  if (isClickOtherBody) {
     $searchCategoryList.classList.remove("list-act");
-    const lists = [...$searchCategoryList.querySelectorAll("li")];
-    lists.reverse();
-    const TRANSITION_TIME = 200;
-    const TIME_CORRECTION = 2;
-    await delayVisible(TRANSITION_TIME / lists.length - TIME_CORRECTION, lists);
   }
-}
+};
 
-async function handleSearchCategoryClick() {
-  const $searchCategoryList = this.$target.querySelector(
+const handleSearchCategoryClick = ({ target }) => {
+  const $searchCategory = target.closest(".search__category");
+  const $searchCategoryList = $searchCategory.parentNode.querySelector(
     ".search__category-list"
   );
   $searchCategoryList.classList.toggle("list-act");
-  const lists = [...$searchCategoryList.querySelectorAll("li")];
-  if (!$searchCategoryList.classList.contains("list-act")) {
-    lists.reverse();
-  }
-  const TRANSITION_TIME = 200;
-  const TIME_CORRECTION = 2;
-  await delayVisible(TRANSITION_TIME / lists.length - TIME_CORRECTION, lists);
-}
+};
 
 export { handleBodyClick, handleSearchCategoryClick };

--- a/src/client/js/components/Header/Search/controllers/searchInput.js
+++ b/src/client/js/components/Header/Search/controllers/searchInput.js
@@ -1,5 +1,5 @@
 import { delay, request } from "../../../../utils";
-import { store } from "../../../../store";
+import { store } from "../../../../Store";
 
 const moveCursorToEnd = ($input, len) => {
   delay(0).then(() => {

--- a/src/client/js/components/Header/Search/controllers/searchInput.js
+++ b/src/client/js/components/Header/Search/controllers/searchInput.js
@@ -1,5 +1,5 @@
 import { delay, request } from "../../../../utils";
-import { store } from "../../../../Store";
+import { store } from "../../../../store";
 
 const moveCursorToEnd = ($input, len) => {
   delay(0).then(() => {
@@ -45,7 +45,6 @@ const handleKeyUpArrowUpDown = ({ target, key }) => {
     searchRecentDisplay === "flex"
       ? recentDatas.length
       : suggestionDatas.length;
-
   const possibleArrowUp = key === "ArrowUp" && selectedInputIdx !== 0;
   const possibleArrowdown =
     key === "ArrowDown" && selectedInputIdx !== MAX_SEARCH_DATA;

--- a/src/client/js/components/Header/Search/controllers/searchInput.js
+++ b/src/client/js/components/Header/Search/controllers/searchInput.js
@@ -15,9 +15,9 @@ const handleInputFocusOut = () => {
 };
 
 const handleInputFocusIn = () => {
-  const { searchWord, recentDatas } = store.state;
+  const { searchWord } = store.state;
   store.setState({
-    searchRecentDisplay: recentDatas.length ? "flex" : "none",
+    searchRecentDisplay: searchWord ? "none" : "flex",
     searchSuggestionDisplay: searchWord ? "flex" : "none",
   });
 };
@@ -36,7 +36,6 @@ const getSelectedData = (target) => {
 const handleKeyUpArrowUpDown = ({ target, key }) => {
   const {
     selectedInputIdx,
-    searchWord,
     suggestionDatas,
     recentDatas,
     searchRecentDisplay,

--- a/src/client/js/components/Header/Search/controllers/searchInput.js
+++ b/src/client/js/components/Header/Search/controllers/searchInput.js
@@ -1,4 +1,5 @@
 import { delay, request } from "../../../../utils";
+import { store } from "../../../../core/Store";
 
 const moveCursorToEnd = ($input, len) => {
   delay(0).then(() => {
@@ -6,72 +7,85 @@ const moveCursorToEnd = ($input, len) => {
   });
 };
 
-function handleInputFocusOut() {
-  const { searchSuggestion, searchRecent } = this.$props;
-  searchSuggestion.setState({ display: "none" });
-  searchRecent.setState({ display: "none" });
-}
+const handleInputFocusOut = () => {
+  store.setState({
+    searchRecentDisplay: "none",
+    searchSuggestionDisplay: "none",
+  });
+};
 
-function handleInputFocusIn() {
-  const { inputData } = this.state;
-  const { searchRecent, searchSuggestion } = this.$props;
-  if (inputData) {
-    searchSuggestion.setState({ display: "flex" });
-    searchRecent.setState({ display: "none" });
+const handleInputFocusIn = () => {
+  const { searchWord } = store.state;
+  if (searchWord) {
+    store.setState({
+      searchRecentDisplay: "none",
+      searchSuggestionDisplay: "flex",
+    });
   } else {
-    searchSuggestion.setState({ display: "none" });
-    searchRecent.setState({ display: "flex" });
+    store.setState({
+      searchRecentDisplay: "flex",
+      searchSuggestionDisplay: "none",
+    });
   }
-}
+};
 
-function handleArrowKeydown({ key }) {
-  const $input = this.$target.querySelector("input");
-  const { searchSuggestion, searchRecent } = this.$props;
-  const {
-    state: { display: sgDisplay },
-  } = searchSuggestion;
-  const curLayout = sgDisplay === "flex" ? searchSuggestion : searchRecent;
-  const { selectedIndex } = curLayout.state;
+const getSelectedData = (target) => {
+  const $suggestionBody =
+    target.parentNode.parentNode.querySelector(".suggestion__body");
+  const $selected = $suggestionBody.querySelector(".selected");
+  return $selected ? $selected.textContent : null;
+};
+
+const handleArrowKeydown = ({ target, key }) => {
+  const { selectedInputIdx } = store.state;
   const MAX_SEARCH_DATA = 9;
-  if (key === "ArrowDown") {
-    if (selectedIndex === MAX_SEARCH_DATA) return;
-    curLayout.setState({ selectedIndex: selectedIndex + 1 });
-    const selectedData = curLayout.getSelectedData();
-    $input.value = selectedData;
-  } else if (key === "ArrowUp") {
-    if (selectedIndex === 0) return;
-    curLayout.setState({ selectedIndex: selectedIndex - 1 });
-    const selectedData = curLayout.getSelectedData();
-    const inputValue =
-      selectedIndex - 1 !== 0 ? selectedData : this.state.inputData;
-    $input.value = inputValue;
-    moveCursorToEnd($input, inputValue.length);
-  }
-}
 
-function handleKeyupWithFocus({ target, key }) {
+  const possibleArrowUp = key === "ArrowUp" && selectedInputIdx !== 0;
+  const possibleArrowdown =
+    key === "ArrowDown" && selectedInputIdx !== MAX_SEARCH_DATA;
+
+  if (!possibleArrowUp && !possibleArrowdown) return;
+
+  store.setState({
+    selectedInputIdx:
+      key === "ArrowDown" ? selectedInputIdx + 1 : selectedInputIdx - 1,
+  });
+
+  const isSelectedIdxZero = selectedInputIdx - 1 === 0;
+
+  const selectedData = isSelectedIdxZero
+    ? store.state.searchWord
+    : getSelectedData(target);
+
+  target.value = selectedData;
+
+  moveCursorToEnd(target, target.value.length);
+};
+
+const handleKeyupWithFocus = ({ target, key }) => {
   if (key === "ArrowDown" || key === "ArrowUp") {
     return;
   }
-  const { searchSuggestion, searchRecent } = this.$props;
-  this.state.inputData = target.value;
   if (target.value) {
-    searchRecent.setState({ display: "none" });
-    searchRecent.setState({ selectedIndex: 0 });
+    store.setState({
+      searchRecentDisplay: "none",
+      selectedInputIdx: 0,
+    });
   } else {
-    searchSuggestion.setState({ display: "none" });
-    searchSuggestion.setState({ selectedIndex: 0 });
-    searchRecent.setState({ display: "flex" });
-    return;
+    store.setState({
+      searchSuggestionDisplay: "none",
+      searchRecentDisplay: "flex",
+      selectedInputIdx: 0,
+    });
   }
   /* 5초 뒤에도 같은 값인지 확인 하기위한 변수 */
-  const curValue = target.value;
+  const searchWord = target.value;
   delay(500).then(async () => {
-    const isFinishInput = this.state.inputData === curValue;
+    const isFinishInput = target.value === searchWord;
     if (isFinishInput) {
       const requestOptions = {
         query: {
-          keyword: curValue,
+          keyword: searchWord,
         },
       };
       const { results: suggestionDatas } = await request(
@@ -79,17 +93,19 @@ function handleKeyupWithFocus({ target, key }) {
         requestOptions
       );
       if (suggestionDatas?.length) {
-        searchSuggestion.setState({
+        store.setState({
           suggestionDatas,
-          word: curValue,
-          display: "flex",
+          searchWord,
+          searchSuggestionDisplay: "flex",
         });
       } else {
-        searchSuggestion.setState({ display: "none" });
+        store.setState({
+          searchSuggestionDisplay: "none",
+        });
       }
     }
   });
-}
+};
 
 export {
   handleInputFocusIn,

--- a/src/client/js/components/Header/Search/controllers/searchInput.js
+++ b/src/client/js/components/Header/Search/controllers/searchInput.js
@@ -18,18 +18,11 @@ const handleInputFocusOut = () => {
 };
 
 const handleInputFocusIn = () => {
-  const { searchWord } = store.state;
-  if (searchWord) {
-    store.setState({
-      searchRecentDisplay: "none",
-      searchSuggestionDisplay: "flex",
-    });
-  } else {
-    store.setState({
-      searchRecentDisplay: "flex",
-      searchSuggestionDisplay: "none",
-    });
-  }
+  const { searchWord, recentDatas } = store.state;
+  store.setState({
+    searchRecentDisplay: recentDatas.length ? "flex" : "none",
+    searchSuggestionDisplay: searchWord ? "flex" : "none",
+  });
 };
 
 const getSelectedData = (target) => {
@@ -83,6 +76,11 @@ const handleKeyUpEnter = ({ target }) => {
   handleInputFocusIn();
 };
 
+const handleSearchIconClick = ({ target }) => {
+  const $input = target.parentNode.parentNode.querySelector("input");
+  handleKeyUpEnter({ target: $input });
+};
+
 const handleKeyupWithFocus = ({ target, key }) => {
   if (key === "ArrowDown" || key === "ArrowUp") {
     handleKeyUpArrowUpDown({ target, key });
@@ -100,7 +98,7 @@ const handleKeyupWithFocus = ({ target, key }) => {
   } else {
     store.setState({
       searchSuggestionDisplay: "none",
-      searchRecentDisplay: "flex",
+      searchRecentDisplay: store.state.recentDatas.length ? "flex" : "none",
       selectedInputIdx: 0,
     });
   }
@@ -133,4 +131,10 @@ const handleKeyupWithFocus = ({ target, key }) => {
   });
 };
 
-export { handleInputFocusIn, handleInputFocusOut, handleKeyupWithFocus };
+export {
+  handleInputFocusIn,
+  handleInputFocusOut,
+  handleKeyupWithFocus,
+  handleKeyUpEnter,
+  handleSearchIconClick,
+};

--- a/src/client/js/components/Header/Search/controllers/searchInput.js
+++ b/src/client/js/components/Header/Search/controllers/searchInput.js
@@ -1,5 +1,5 @@
 import { delay, request } from "../../../../utils";
-import { store } from "../../../../core/Store";
+import { store } from "../../../../Store";
 
 const moveCursorToEnd = ($input, len) => {
   delay(0).then(() => {

--- a/src/client/js/components/Header/Search/controllers/searchSuggestion.js
+++ b/src/client/js/components/Header/Search/controllers/searchSuggestion.js
@@ -1,0 +1,15 @@
+const highlightWord = (string, word) => {
+  const matchedWordRegex = new RegExp(
+    `(?<front>.+)?(?<matchedWord>${word})(?<back>.+)?`
+  );
+  const { groups } = string.match(matchedWordRegex) || { groups: {} };
+  const { front, matchedWord, back } = groups;
+
+  return matchedWord
+    ? `${front || ""}<span class="matchedWord">${matchedWord}</span>${
+        back || ""
+      }`
+    : string;
+};
+
+export { highlightWord };

--- a/src/client/js/core/Component.js
+++ b/src/client/js/core/Component.js
@@ -1,8 +1,7 @@
 import { observe } from "./observer";
 
-export default function Component($target, $props) {
+export default function Component($target) {
   this.$target = $target;
-  this.$props = $props;
 }
 
 Component.prototype = {

--- a/src/client/js/core/Component.js
+++ b/src/client/js/core/Component.js
@@ -1,3 +1,5 @@
+import { observe } from "./observer";
+
 export default function Component($target, $props) {
   this.$target = $target;
   this.$props = $props;
@@ -5,9 +7,11 @@ export default function Component($target, $props) {
 
 Component.prototype = {
   constructor: Component,
-  async initRender() {
+  initRender() {
     this.setup();
-    await this.render();
+    observe(async () => {
+      await this.render();
+    });
     this.setEvent();
   },
   setup() {

--- a/src/client/js/core/Component.js
+++ b/src/client/js/core/Component.js
@@ -17,10 +17,6 @@ Component.prototype = {
   setup() {
     // this.state 초기 셋업
   },
-  setState(newState) {
-    this.state = { ...this.state, ...newState };
-    this.render();
-  },
   async mount() {
     // render 이후 로직 실행
   },

--- a/src/client/js/core/Store.js
+++ b/src/client/js/core/Store.js
@@ -1,9 +1,8 @@
 import { observable } from "./observer";
 
 const initState = {
-  a: 1,
-  b: 0,
   categoryTitle: "전체",
+  categoryDatas: [],
   searchRecentDisplay: "none",
   searchSuggestionDisplay: "none",
   selectedInputIdx: 0,

--- a/src/client/js/core/Store.js
+++ b/src/client/js/core/Store.js
@@ -1,0 +1,21 @@
+import { observable } from "./observer";
+
+const initState = {
+  a: 1,
+  b: 0,
+  categoryTitle: "전체",
+  searchRecentDisplay: "none",
+  searchSuggestionDisplay: "none",
+  selectedInputIdx: 0,
+  suggestionDatas: [],
+  searchWord: "",
+};
+
+export const store = {
+  state: observable(initState),
+  setState(newState) {
+    Object.entries(newState).forEach(([key, value]) => {
+      this.state[key] = value;
+    });
+  },
+};

--- a/src/client/js/core/observer.js
+++ b/src/client/js/core/observer.js
@@ -1,0 +1,26 @@
+let currentObserver = null;
+
+export const observe = (fn) => {
+  currentObserver = fn;
+  fn();
+  currentObserver = null;
+};
+
+export const observable = (obj) => {
+  Object.keys(obj).forEach((key) => {
+    let value = obj[key];
+    const observers = new Set();
+
+    Object.defineProperty(obj, key, {
+      get() {
+        if (currentObserver) observers.add(currentObserver);
+        return value;
+      },
+      set(newValue) {
+        value = newValue;
+        observers.forEach((fn) => fn());
+      },
+    });
+  });
+  return obj;
+};

--- a/src/client/js/core/observer.js
+++ b/src/client/js/core/observer.js
@@ -10,7 +10,6 @@ export const observable = (obj) => {
   Object.keys(obj).forEach((key) => {
     let value = obj[key];
     const observers = new Set();
-
     Object.defineProperty(obj, key, {
       get() {
         if (currentObserver) observers.add(currentObserver);

--- a/src/client/js/core/observer.js
+++ b/src/client/js/core/observer.js
@@ -1,9 +1,9 @@
-let currentObserver = null;
+let currentRenderer = null;
 
-export const observe = (fn) => {
-  currentObserver = fn;
-  fn();
-  currentObserver = null;
+export const observe = (render) => {
+  currentRenderer = render;
+  render();
+  currentRenderer = null;
 };
 
 export const observable = (obj) => {
@@ -12,7 +12,7 @@ export const observable = (obj) => {
     const observers = new Set();
     Object.defineProperty(obj, key, {
       get() {
-        if (currentObserver) observers.add(currentObserver);
+        if (currentRenderer) observers.add(currentRenderer);
         return value;
       },
       set(newValue) {

--- a/src/client/scss/_header.scss
+++ b/src/client/scss/_header.scss
@@ -129,6 +129,9 @@ i {
   border: 1px $baseLightGray solid;
   box-shadow: 0 4px 5px rgb(0 0 0 / 30%);
   font-size: nth($fontSizes, 1);
+  .selected {
+    text-decoration: underline;
+  }
 }
 
 .layout__body {
@@ -159,6 +162,9 @@ i {
   }
   .recent__body {
     @extend .layout__body;
+    .selected {
+      color: $baseBlue;
+    }
   }
   .recent__footer {
     @include flex(space-between, center);
@@ -177,9 +183,6 @@ i {
     @extend .layout__body;
     .matchedWord {
       color: $baseBlue;
-    }
-    .selected {
-      text-decoration: underline;
     }
   }
 }

--- a/src/client/scss/_header.scss
+++ b/src/client/scss/_header.scss
@@ -111,6 +111,7 @@ i {
       margin: 0px 3px;
     }
     i {
+      cursor: pointer;
       font-size: nth($fontSizes, 3);
       color: $baseBlue;
     }

--- a/src/client/scss/_header.scss
+++ b/src/client/scss/_header.scss
@@ -76,21 +76,18 @@ i {
 
   .search__category-list {
     cursor: pointer;
-    visibility: hidden;
+    overflow: hidden;
     position: absolute;
     left: -1px;
     top: 30px;
     max-height: 0px;
     width: 100px;
     background-color: $baseBgColor;
-    border: 1px $baseLightGray solid;
     font-size: nth($fontSizes, 1);
     color: $baseGray;
-    box-shadow: 0 4px 5px rgb(0 0 0 / 30%);
-    transition: all 0.2s;
+    transition: max-height 0.2s;
     li {
       cursor: pointer;
-      visibility: hidden;
       padding: 5px;
       margin: 5px 0px;
       &:hover {
@@ -100,8 +97,9 @@ i {
     }
   }
   .list-act {
-    visibility: visible;
     max-height: 1000px;
+    box-shadow: 0 4px 5px rgb(0 0 0 / 30%);
+    border: 1px $baseLightGray solid;
   }
   .search__input {
     @include flex(space-around, center);

--- a/src/client/scss/_header.scss
+++ b/src/client/scss/_header.scss
@@ -98,8 +98,6 @@ i {
   }
   .list-act {
     max-height: 1000px;
-    box-shadow: 0 4px 5px rgb(0 0 0 / 30%);
-    border: 1px $baseLightGray solid;
   }
   .search__input {
     @include flex(space-around, center);


### PR DESCRIPTION
## 데모

<a href="https://fe-shopping.herokuapp.com/">링크</a>

![23pr](https://user-images.githubusercontent.com/58503584/159617244-42b6fa6c-2cf7-446e-a939-c3807edb62a2.gif)

task list

- [x] +) 최근 검색어는 localStorage 에 저장해서 저장하고, 불러오기
- [x] +) 키보드 위/아래 이동시 이동 -> Suggestion 과 Recent 가 동일한 Index 로
- [x] Store 분리

### Store(Model) 를 분리해서 처리

- 기존의 각각의 컴포넌트들이 갖는 state 를 store 가 모두 갖도록 분리했습니다.
- store 를 분리하고서 어떻게 store 가 notify 해야할 지 고민을 많이해보았는데 떠오르는 방법은 모두 실패해서 작성된 옵저버패턴을 참고해서 코드를 작성했습니다. (core/observer)

### Store 를 쓰면서 느낀 단점?

- store + observer 패턴 을 쓰면서 아쉬웠던 점은 `store 가 모든 state 를 갖게되어서 어느 Component 에서 쓰이는지 확인하기 어렵다` 는 것이었습니다.

- 만약 store의 state 가 너무 커진다면 어떤 Component 에서 쓰는지 구분하기 어렵지 않을까? 란 생각을 했습니다.
  - 그래서 state 안에 어느 Component 에서 쓰이는지 작성하는 식으로 하고 flat 시켜서 넣으면 되지않을까? 싶었는데 하나의 State 를 두 개의 Component 에서 쓰는 경우도 있을 것 같아 중복으로 보여져서 꺼려지게 되었습니다. Component 별 state 를 어떻게 명시적으로 보여줄 지를 좀 더 고민해봐야겠다는 생각을 했습니다.

```js
const initState = {
  categoryTitle: "전체",
  categoryDatas: [],
  searchWord: "",
  searchRecentDisplay: "none",
  searchSuggestionDisplay: "none",
  suggestionDatas: [],
  recentDatas: JSON.parse(localStorage.getItem("recent")) || [],
  selectedInputIdx: 0,
};

// 생각해본 방법..
const initState = {
  categoryState: {
    categoryTitle: "전체",
    categoryDatas: [],
  },
  searchState: {
    searchWord: "",
    searchRecentDisplay: "none",
    searchSuggestionDisplay: "none",
  },
  searchSuggestionState: {
    suggestionDatas: [],
    selectedInputIdx: 0,
  },
  searchRecentState: {
    recentDatas: JSON.parse(localStorage.getItem("recent")) || [],
    selectedInputIdx: 0, // 중복으로 쓰여짐, 의미없는 값이 되는데..?
  },
};
```

### Store 를 쓰면서 느낀 장점

- `Component` 에서 분리된 `Store` 에서 `state` 를 가져오는 방식으로 하니 `$props` 를 통해서 전달하던 복잡한 로직에서 벗어날 수 있었고, `View` 간에 결합성이 떨어져 각각의 `Component` 를 작업하는 데 생기는 부수효과가 적어져서 유지보수가 용이해졌다는 생각이 들었습니다.

- 또한 하나의 state 에서 property 를 관리하다보니 뜻하지않게 변수명이 구체적이게 되어서 가독성이 더 좋아졌다는 느낌을 받았습니다.

- 단점대비 장점이 훨씬 많은 느낌을 받아서, Store 를 쓰지않을 이유가 없다는 생각이 들었습니다.

### +a) deploy 버그관련..
- heroku 에 deploy 하면서 계속 webpack build 오류가 났었는데, store module 을 찾지 못한다는 오류였습니다.
- 왜그러지..? 싶었는데 이유는 `Store.js 라고 지었던 파일명을 store.js 로 변경했었는데, git 이 이 파일명이 바뀐것을 트래킹하지 못하는 것 같았습니다. (대문자->소문자 로 바꿔서?)`
- git 이 파일명이 바뀐 것을 트래킹하지 못해서 heroku 에 올려진 코드가 build 할 때 깃에는 Store 라고 올려져 있어서 store 를 찾지 못했던 것이었습니다.. 파일명이 대소문자가 바뀌었을 때는 깃이 트래킹하지 않는구나~ 라는 것을 알았습니다.