### PR TITLE
[S] Step3

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -166,4 +166,8 @@ header .category-button span {
   padding: 5px;
   margin: 6px;
 }
+
+.search-bar .popup-keywords .relative-keyword-list strong {
+  color: #4285f4;
+}
 /*# sourceMappingURL=main.css.map */

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -167,6 +167,28 @@ header .category-button span {
   margin: 6px;
 }
 
+.search-bar .popup-keywords .recent-search-list li {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+}
+
+.search-bar .popup-keywords .recent-search-list li:hover button {
+  visibility: visible;
+}
+
+.search-bar .popup-keywords .recent-search-list li button {
+  visibility: hidden;
+  border: 0;
+  background-color: #fff;
+}
+
 .search-bar .popup-keywords .relative-keyword-list strong {
   color: #4285f4;
 }

--- a/static/js/controller/recentSearchController.js
+++ b/static/js/controller/recentSearchController.js
@@ -9,21 +9,35 @@ export class RecentSearchController {
     this.$popupKeywords = document.querySelector('.popup-keywords');
   }
   
-  addInputFocusEvent () {
+  addInputFocusEvent() {
     this.$input.addEventListener('focus', () => {
       if (!this.recentSearchModel.isEmpty()) {
         this.$popupKeywords.classList.remove('hidden');
       }
       this.recentSearchModel.updateKeywordList();
-      this.recentSearchView.renderRecentSearch(this.recentSearchModel.keywordList);
+      const keywordList = this.recentSearchModel.keywordList;
+      const keywordIndexList = this.recentSearchModel.keywordIndexList;
+      this.recentSearchView.renderRecentSearch(keywordList, keywordIndexList);
     });
   }
 
-  addInputKeyDownEvent () {
+  addInputKeyDownEvent() {
     this.$input.addEventListener('keydown', (event) => {
       if (event.key === 'Enter') {
         this.recentSearchModel.addKeyword(event.target.value);
         event.target.value = '';
+      }
+    });
+  }
+  addPopupKeywordsClickEvent() {
+    this.$popupKeywords.addEventListener('click', (event) => {
+      const $recentKeyword = event.target.closest('li');
+      if ($recentKeyword) {
+        const selectedKeywordIndex =  $recentKeyword.dataset.index;
+        this.recentSearchModel.deleteKeyword(selectedKeywordIndex);
+        const keywordList = this.recentSearchModel.keywordList;
+        const keywordIndexList = this.recentSearchModel.keywordIndexList;
+        this.recentSearchView.renderRecentSearch(keywordList, keywordIndexList);
       }
     });
   }

--- a/static/js/controller/recentSearchController.js
+++ b/static/js/controller/recentSearchController.js
@@ -3,7 +3,7 @@ import {RecentSearchView} from '../view/recentSearchView.js';
 
 export class RecentSearchController {
   constructor() {
-    this.recentSearchModel = new RecentSearchModel(window.localStorage);
+    this.recentSearchModel = new RecentSearchModel(window.sessionStorage);
     this.recentSearchView = new RecentSearchView();
     this.$input = document.querySelector('.search-bar-input');
     this.$popupKeywords = document.querySelector('.popup-keywords');
@@ -14,14 +14,13 @@ export class RecentSearchController {
       if (!this.recentSearchModel.isEmpty()) {
         this.$popupKeywords.classList.remove('hidden');
       }
-      this.recentSearchModel.createKeywordList();
+      this.recentSearchModel.updateKeywordList();
       this.recentSearchView.renderRecentSearch(this.recentSearchModel.keywordList);
     });
   }
 
   addInputKeyDownEvent () {
     this.$input.addEventListener('keydown', (event) => {
-      this.$popupKeywords.classList.add('hidden');
       if (event.key === 'Enter') {
         this.recentSearchModel.addKeyword(event.target.value);
         event.target.value = '';

--- a/static/js/controller/relativeSearchController.js
+++ b/static/js/controller/relativeSearchController.js
@@ -17,8 +17,7 @@ export class RelativeSearchController {
         return;
       }
       const searchKeyword = event.target.value;
-      if (searchKeyword !== '')
-      {
+      if (searchKeyword !== '') {
         this.updatePopupRelativeKeyword(searchKeyword);
       }
     }, delayTime));

--- a/static/js/controller/relativeSearchController.js
+++ b/static/js/controller/relativeSearchController.js
@@ -10,13 +10,54 @@ export class RelativeSearchController {
     this.$popupKeywords = document.querySelector('.popup-keywords');
   }
 
-  addInputKeyUpEvent () {
+  addInputKeyUpEvent() {
     const delayTime = 500;
-    this.$input.addEventListener('keyup', debounce(({target}) => {
-      const searchKeyword = target.value;
-      if (searchKeyword === '') return;
-      const keywordList = this.relativeSearchModel.createKeywordList(searchKeyword);
-      console.log(keywordList);
-      }, delayTime));
+    this.$input.addEventListener('keyup', debounce((event) => {
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        return;
+      }
+      const searchKeyword = event.target.value;
+      if (searchKeyword !== '')
+      {
+        this.updatePopupRelativeKeyword(searchKeyword);
+      }
+    }, delayTime));
+  }
+
+  addInputKeyDownEvent() {
+    let keywordListNumber = 0;
+    this.$input.addEventListener('keydown', (event) => {
+      if (this.relativeSearchModel.isEmpty()) {
+        return;
+      }
+      const keywordListLength = this.relativeSearchModel.keywordList.length;
+      if (event.key === 'ArrowDown') {
+        keywordListNumber++;
+        if (keywordListNumber > keywordListLength) {
+          keywordListNumber = 1;
+        }
+      } else if (event.key === 'ArrowUp') {
+        keywordListNumber--;
+        if (keywordListNumber < 1) {
+          keywordListNumber = keywordListLength;
+        }
+      }
+      const $relativeKeywordList = document.querySelector(`.relative-keyword-list`);
+      const $selectedKeyword = $relativeKeywordList.querySelector(`li:nth-child(${keywordListNumber})`);
+      if (!$selectedKeyword) {
+        return;
+      }
+      event.target.value = $selectedKeyword.innerText;
+    });
+  }
+
+  updatePopupRelativeKeyword(searchKeyword) {
+    this.$popupKeywords.innerHTML = '';
+    this.$popupKeywords.classList.remove('hidden');
+    const keywordList = this.relativeSearchModel.updateKeywordList(searchKeyword);
+    if (keywordList.length === 0) {
+        return;
+      }
+    this.relativeSearchView.renderRelativeSearch(keywordList, searchKeyword);
   }
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -13,6 +13,7 @@ function init() {
   const relativeSearchController = new RelativeSearchController(keywordsData);
   recentSearchController.addInputFocusEvent();
   recentSearchController.addInputKeyDownEvent();
+  recentSearchController.addPopupKeywordsClickEvent();
   relativeSearchController.addInputKeyUpEvent();
   relativeSearchController.addInputKeyDownEvent();
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -9,10 +9,10 @@ const keywordsData = goodsData[firstKeyword];
 init();
 
 function init() {
-  window.localStorage.clear();
   const recentSearchController = new RecentSearchController();
   const relativeSearchController = new RelativeSearchController(keywordsData);
   recentSearchController.addInputFocusEvent();
   recentSearchController.addInputKeyDownEvent();
   relativeSearchController.addInputKeyUpEvent();
+  relativeSearchController.addInputKeyDownEvent();
 }

--- a/static/js/model/recentSearchModel.js
+++ b/static/js/model/recentSearchModel.js
@@ -1,6 +1,7 @@
-export class RecentSearchModel {
+class RecentSearchModel {
   constructor(localStorage) {
     this.storage = localStorage;
+    this.keywordIndexList = [];
     this.keywordList = [];
   }
 
@@ -9,26 +10,27 @@ export class RecentSearchModel {
   }
 
   addKeyword(keyword) {
-    const keywordList = Object.values(this.storage);
     const keywordListMaxLength = 9;
-    if (keywordList.includes(keyword)) {
+    if (this.keywordList.includes(keyword)) {
       return;
     }
-    if (keywordList.length >= keywordListMaxLength) {
-      const oldKeyword = keywordList[0];
+    if (this.keywordList.length >= keywordListMaxLength) {
+      const oldestKeywordIndex = this.keywordIndexList[0];
+      this.storage.removeItem(oldestKeywordIndex);
       this.keywordList.splice(0, 1);
-      this.storage.removeItem(oldKeyword);
     }
-    this.storage.setItem(Date.now(), keyword);
+    const keywordIndex = Date.now();
+    this.storage.setItem(keywordIndex, keyword);
+    this.keywordIndexList.push(keywordIndex);
     this.keywordList.push(keyword);
   }
 
   updateKeywordList() {
-    const localStorageIndice = Object.keys(this.storage).sort();
-    const keywordList = localStorageIndice
-    .filter((storageIndex) => Number(storageIndex))
-    .map((storageIndex) => this.storage[storageIndex]);
-    console.log(keywordList);
+    const localStorageKeys = Object.keys(this.storage)
+    .filter((storageKey) => Number(storageKey))
+    .sort();
+    const keywordList = localStorageKeys.map((storageKey) => this.storage[storageKey]);
+    this.keywordIndexList = localStorageKeys;
     this.keywordList = keywordList;
   }
 }

--- a/static/js/model/recentSearchModel.js
+++ b/static/js/model/recentSearchModel.js
@@ -1,4 +1,4 @@
-class RecentSearchModel {
+export class RecentSearchModel {
   constructor(localStorage) {
     this.storage = localStorage;
     this.keywordIndexList = [];
@@ -27,10 +27,16 @@ class RecentSearchModel {
 
   updateKeywordList() {
     const localStorageKeys = Object.keys(this.storage)
-    .filter((storageKey) => Number(storageKey))
-    .sort();
+      .filter((storageKey) => Number(storageKey))
+      .sort();
     const keywordList = localStorageKeys.map((storageKey) => this.storage[storageKey]);
     this.keywordIndexList = localStorageKeys;
     this.keywordList = keywordList;
+  }
+
+  deleteKeyword(selectedKeywordIndex) {
+    this.keywordIndexList = this.keywordIndexList.filter((keywordIndex) => keywordIndex !== selectedKeywordIndex);
+    this.keywordList = this.keywordList.filter((keyword) => keyword !== this.storage[selectedKeywordIndex]);
+    this.storage.removeItem(selectedKeywordIndex);
   }
 }

--- a/static/js/model/recentSearchModel.js
+++ b/static/js/model/recentSearchModel.js
@@ -23,11 +23,12 @@ export class RecentSearchModel {
     this.keywordList.push(keyword);
   }
 
-  createKeywordList() {
-    const localStorageIndice = Object.keys(this.storage);
-    let keywordList = localStorageIndice.map((storageIndex) => {
-      return this.storage[storageIndex];
-    });
+  updateKeywordList() {
+    const localStorageIndice = Object.keys(this.storage).sort();
+    const keywordList = localStorageIndice
+    .filter((storageIndex) => Number(storageIndex))
+    .map((storageIndex) => this.storage[storageIndex]);
+    console.log(keywordList);
     this.keywordList = keywordList;
   }
 }

--- a/static/js/model/relativeSearchModel.js
+++ b/static/js/model/relativeSearchModel.js
@@ -4,14 +4,13 @@ export class RelativeSearchModel {
     this.keywordList = [];
   }
 
-  createKeywordList(searchKeyword) {
-    const keywordList = this.data.reduce((keywordList, data) => {
-      const keyword = data.keyword;
-      if (keyword.includes(searchKeyword)) {
-        keywordList.push(keyword);
-      }
-      return keywordList;
-    }, []);
+  isEmpty() {
+    return this.keywordList.length === 0;
+  }
+
+  updateKeywordList(searchKeyword) {
+    const keywordList = this.data.filter(({keyword}) => keyword.includes(searchKeyword));
+    this.keywordList = keywordList;
     return keywordList;
   }
 }

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -1,22 +1,17 @@
-export function fetchData(dataName) {
+export async function fetchData(dataName) {
   const DATA_URL = `http://localhost:3000/${dataName}`;
-  return fetch(DATA_URL)
-  .then((response) => {
-    if (!response.ok) {
-      throw new Error(response.statusText);
-    }
+  const response = await fetch(DATA_URL);
+  if (!response.ok) {
+    return response.text().then(text => {throw new Error(text)});
+  }
     return response.json();
-  })
-  .catch((error) => {
-    console.error('Error:', error);
-  });
 }
 
 export function debounce(func, delay) {
-  let inDebounce;
+  let timeoutId;
   return function(...args) {
     const context = this;
-    clearTimeout(inDebounce);
-    inDebounce = setTimeout(() => func.apply(context, args), delay);
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => func.apply(context, args), delay);
   }
 }

--- a/static/js/view/recentSearchView.js
+++ b/static/js/view/recentSearchView.js
@@ -1,13 +1,23 @@
-import {SearchView} from './searchView.js'
-
-export class RecentSearchView extends SearchView {
+export class RecentSearchView {
   constructor() {
-    super();
     this.$popupKeywords = document.querySelector('.popup-keywords');
   }
-  renderRecentSearch(keywordList) {
+
+  createKeywordsTemplate(keywordList, keywordIndexList, listClassName) {
+    let keywordsTemplate = keywordList.reduce((template, keyword, index) => {
+      template += `<li data-index=${keywordIndexList[index]}>
+      ${keyword}
+      <button type='button' class='recent-keyword-button'>X</button>
+      </li>`;
+      return template;
+    }, `<ul class=${listClassName}>`);
+    keywordsTemplate += '</ul>';
+    return keywordsTemplate;
+  }
+
+  renderRecentSearch(keywordList, keywordIndexList) {
     let popupKeywordsTemplate = '<h3 class="recent-search-text">최근 검색어</h3>';
-    const keywordsTemplate = super.createKeywordsTemplate(keywordList, 'recent-search-list');
+    const keywordsTemplate = this.createKeywordsTemplate(keywordList, keywordIndexList, 'recent-search-list');
     popupKeywordsTemplate += keywordsTemplate;
     this.$popupKeywords.innerHTML = popupKeywordsTemplate;
   }

--- a/static/js/view/recentSearchView.js
+++ b/static/js/view/recentSearchView.js
@@ -7,7 +7,7 @@ export class RecentSearchView extends SearchView {
   }
   renderRecentSearch(keywordList) {
     let popupKeywordsTemplate = '<h3 class="recent-search-text">최근 검색어</h3>';
-    let keywordsTemplate = super.createKeywordsTemplate(keywordList, 'recent-search-list');
+    const keywordsTemplate = super.createKeywordsTemplate(keywordList, 'recent-search-list');
     popupKeywordsTemplate += keywordsTemplate;
     this.$popupKeywords.innerHTML = popupKeywordsTemplate;
   }

--- a/static/js/view/recentSearchView.js
+++ b/static/js/view/recentSearchView.js
@@ -4,7 +4,7 @@ export class RecentSearchView {
   }
 
   createKeywordsTemplate(keywordList, keywordIndexList, listClassName) {
-    let keywordsTemplate = keywordList.reduce((template, keyword, index) => {
+    const keywordsTemplate = keywordList.reduce((template, keyword, index) => {
       template += `<li data-index=${keywordIndexList[index]}>
       ${keyword}
       <button type='button' class='recent-keyword-button'>X</button>
@@ -16,9 +16,9 @@ export class RecentSearchView {
   }
 
   renderRecentSearch(keywordList, keywordIndexList) {
-    let popupKeywordsTemplate = '<h3 class="recent-search-text">최근 검색어</h3>';
+    const textTemplate = '<h3 class="recent-search-text">최근 검색어</h3>';
     const keywordsTemplate = this.createKeywordsTemplate(keywordList, keywordIndexList, 'recent-search-list');
-    popupKeywordsTemplate += keywordsTemplate;
+    const popupKeywordsTemplate = textTemplate + keywordsTemplate;
     this.$popupKeywords.innerHTML = popupKeywordsTemplate;
   }
 }

--- a/static/js/view/relativeSearchView.js
+++ b/static/js/view/relativeSearchView.js
@@ -5,8 +5,22 @@ export class RelativeSearchView extends SearchView {
     super();
     this.$popupKeywords = document.querySelector('.popup-keywords');
   }
-  renderRecentSearch(keywordList) {
-    const keywordsTemplate = super.createKeywordsTemplate(keywordList);
+
+  createHighlightKeywordList(keywordList, searchKeyword) {
+    const highlightedKeywordList = keywordList.map((keyword) => {
+      const highlightKeywordIndex = keyword.indexOf(searchKeyword);
+      const leftKeyword = keyword.slice(0, highlightKeywordIndex);
+      const rightKeyword = keyword.slice(highlightKeywordIndex + searchKeyword.length);
+      const highlightedKeyword = `${leftKeyword}<strong>${searchKeyword}</strong>${rightKeyword}`;
+      return highlightedKeyword;
+    });
+    return highlightedKeywordList;
+  }
+
+  renderRelativeSearch(keywordList, searchKeyword) {
+    const relativeKeywordsList = keywordList.map(({keyword}) => keyword);
+    const highlightedKeywordList = this.createHighlightKeywordList(relativeKeywordsList, searchKeyword);
+    const keywordsTemplate = super.createKeywordsTemplate(highlightedKeywordList, 'relative-keyword-list');
     this.$popupKeywords.innerHTML = keywordsTemplate;
   }
 }

--- a/static/scss/abstract/_constant.scss
+++ b/static/scss/abstract/_constant.scss
@@ -1,4 +1,4 @@
 $url : url(https://static.coupangcdn.com/image/coupang/common/pc_header_img_sprite_180104.png);
-$font-white: #fff;
-$font-blue: #4285f4;
-$font-gray: #ddd;
+$color-white: #fff;
+$color-blue: #4285f4;
+$color-gray: #ddd;

--- a/static/scss/component/_header-category.scss
+++ b/static/scss/component/_header-category.scss
@@ -13,7 +13,7 @@ header {
     span {
       margin-top: 73px;
       font-size: 13px;
-      color: $font-white;
+      color: $color-white;
     }
   }
 }

--- a/static/scss/component/_header-main-menu.scss
+++ b/static/scss/component/_header-main-menu.scss
@@ -12,6 +12,6 @@
     width: 522px;
     height: 41px;
     margin: 0 22px;
-    border: 2px solid $font-blue;
+    border: 2px solid $color-blue;
   }
 }

--- a/static/scss/component/_search-box-search-bar.scss
+++ b/static/scss/component/_search-box-search-bar.scss
@@ -40,5 +40,11 @@
       padding: 5px;
       margin: 6px;
     }
+
+    .relative-keyword-list {
+      strong {
+        color: $font-blue;
+      }
+    }
   }
 }

--- a/static/scss/component/_search-box-search-bar.scss
+++ b/static/scss/component/_search-box-search-bar.scss
@@ -23,15 +23,15 @@
     height: auto;
     padding: 10px;
     margin: 0 auto;
-    border: 1px solid $font-gray;
-    box-shadow: 0 2px 3px $font-gray;
+    border: 1px solid $color-gray;
+    box-shadow: 0 2px 3px $color-gray;
 
     .recent-search-text {
       position: relative;
       height: 11px;
       padding: 5px;
       margin: 6px;
-      border-bottom: 1px solid $font-gray;
+      border-bottom: 1px solid $color-gray;
       line-height: 0;
       font-size: 14px;
     }
@@ -39,11 +39,25 @@
     .recent-search-list {
       padding: 5px;
       margin: 6px;
+
+      li {
+        @include flexbox(space-between, center);
+        &:hover {
+          button {
+            visibility: visible;
+          }
+        }
+        button {
+          visibility: hidden;
+          border: 0;
+          background-color: $color-white;
+        }
+      }
     }
 
     .relative-keyword-list {
       strong {
-        color: $font-blue;
+        color: $color-blue;
       }
     }
   }


### PR DESCRIPTION
### 구현내용
- 연관검색어의 검색어부분 하이라이트 기능 구현
- 연관검색어 목록을 방향키로 탐색하는 기능 구현
- 방향키로 선택된 연관검색어의 자동 완성 기능 구현
- 최근검색어 목록에서 클릭된 최근검색어 개별 삭제 기능 구현

### 미션 요구사항
- [ ] 스마트 레이어에 Debounce나 Throttling 방식을 사용한다.
- [X] 비동기 함수 안에 비동기 코드가 위치하지 않는다.
- [X] Store와  View를 분리한다.

### 궁금한 점
- 연관검색어 목록을 방향키로 탐색할 때 이전에 탐색한 적이 있다면, 연관검색어 목록을 처음부터 탐색하는 것이 아니라 이전에 탐색한 연관검색어 위치에서부터 탐색됩니다. 
어떻게 연관검색어의 탐색에 쓰이는 인덱스를 초기화할 수 있을까요?
 addEventListener 함수 내에서 인덱스를 초기화하면 다음 연관검색어가 탐색되지 않고, addEventListener 함수 밖에서 인덱스를 초기화하면 다음 연관검색어도 탐색되지만, 다른 연관검색어 목록을 탐색할 경우에도 인덱스가 초기화가 안 됩니다;; 

### 코드 리뷰 잘 부탁드립니다 🙏