### PR TITLE
[J] 최근검색어 추가작업, 자동완성 검색어

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
                       </div>
                       <div class="recent_controll">
                         <button type="button" data-recent="deleteAll">전체 삭제</button>
-                        <button type="button" data-recent="off">최신검색어끄기</button>
+                        <button type="button" class="recent_mode_btn" data-recent="modeBtn" data-mode="off">최근검색어끄기</button>
                       </div>
                     </div>
                   </div>

--- a/index.html
+++ b/index.html
@@ -101,8 +101,8 @@
                         </a>
                       </div>
                       <div class="recent_controll">
-                        <button type="button">전체 삭제</button>
-                        <button type="button">최신검색어끄기</button>
+                        <button type="button" data-recent="deleteAll">전체 삭제</button>
+                        <button type="button" data-recent="off">최신검색어끄기</button>
                       </div>
                     </div>
                   </div>

--- a/index.html
+++ b/index.html
@@ -101,8 +101,8 @@
                         </a>
                       </div>
                       <div class="recent_controll">
-                        <button type="button" data-recent="deleteAll">전체 삭제</button>
-                        <button type="button" class="recent_mode_btn" data-recent="modeBtn" data-mode="off">최근검색어끄기</button>
+                        <button type="button" data-blur="deleteAll">전체 삭제</button>
+                        <button type="button" class="recent_mode_btn" data-blur="modeBtn" data-mode="off">최근검색어끄기</button>
                       </div>
                     </div>
                   </div>

--- a/public/js/header/search/autoCompleteController.js
+++ b/public/js/header/search/autoCompleteController.js
@@ -1,0 +1,30 @@
+import { getData } from '../../util/util.js';
+import { autoCompleteKeywordTemp } from './searchTemplate.js';
+
+class AutoCompleteController {
+  constructor() {
+    this.timer = null;
+  }
+
+  getRecomKeyword(keyword, renderFuc) {
+    if (!keyword) {
+      this.clearTimer();
+      this.timer = null;
+      return;
+    }
+
+    const AMAZON_API = `https://completion.amazon.com/api/2017/suggestions?session-id=133-4736477-7395454&customer-id=&request-id=4YM3EXKRH1QJB16MSJGT&page-type=Gateway&lop=en_US&site-variant=desktop&client-info=amazon-search-ui&mid=ATVPDKIKX0DER&alias=aps&b2b=0&fresh=0&ks=71&prefix=${keyword}&event=onKeyPress&limit=11&fb=1&suggestion-type=KEYWORD`;
+    this.clearTimer();
+    this.timer = setTimeout(function () {
+      getData(AMAZON_API)
+        .then((data) => autoCompleteKeywordTemp(keyword, data.suggestions))
+        .then((html) => renderFuc(html));
+    }, 500);
+  }
+
+  clearTimer() {
+    clearTimeout(this.timer);
+  }
+}
+
+export { AutoCompleteController };

--- a/public/js/header/search/categorySelect.js
+++ b/public/js/header/search/categorySelect.js
@@ -18,7 +18,7 @@ class CategorySelector {
   }
 
   getOption() {
-    getData('search/category')
+    getData('http://localhost:3000/search/category')
       .then((data) => categoryTemp(data))
       .then((data) => (this.categoryList.innerHTML = data))
       .then(toggleClass(this.selectBox, this.toggleClassName));

--- a/public/js/header/search/search.js
+++ b/public/js/header/search/search.js
@@ -56,6 +56,9 @@ class Search {
       case 'deleteAll':
         this.searchBar.deleteRecentKeyword();
         break;
+      case 'modeBtn':
+        this.searchBar.changeRecentMode(relatedTarget, this.searchInput);
+        break;
       default:
         this.searchBar.hideRecomBox();
     }

--- a/public/js/header/search/search.js
+++ b/public/js/header/search/search.js
@@ -37,16 +37,13 @@ class Search {
 
     switch (target.dataset.search) {
       case 'selectorBtn':
-        this.categorySelector.dropDownMenu.call(this.categorySelector);
+        this.categorySelector.dropDownMenu();
         break;
       case 'searchCategory':
-        this.categorySelector.selectCategory.call(
-          this.categorySelector,
-          target
-        );
+        this.categorySelector.selectCategory(target);
         break;
       case 'submitBtn':
-        this.searchBar.searchKeyword.call(this.searchBar, this.searchInput);
+        this.searchBar.searchKeyword(this.searchInput);
         break;
       default:
         return;

--- a/public/js/header/search/search.js
+++ b/public/js/header/search/search.js
@@ -22,7 +22,10 @@ class Search {
 
     this.searchInput.addEventListener(
       'input',
-      this.searchBar.init.bind(this.searchBar, this.searchInput)
+      this.searchBar.getAutoCompleteKeyword.bind(
+        this.searchBar,
+        this.searchInput
+      )
     );
 
     this.searchInput.addEventListener('blur', this.blurHandler.bind(this));
@@ -52,12 +55,15 @@ class Search {
       this.searchBar.hideRecomBox();
       return;
     }
-    switch (relatedTarget.dataset.recent) {
+    switch (relatedTarget.dataset.blur) {
       case 'deleteAll':
         this.searchBar.deleteRecentKeyword();
         break;
       case 'modeBtn':
         this.searchBar.changeRecentMode(relatedTarget, this.searchInput);
+        break;
+      case 'keyword':
+        console.log('키워드 선택');
         break;
       default:
         this.searchBar.hideRecomBox();

--- a/public/js/header/search/search.js
+++ b/public/js/header/search/search.js
@@ -25,13 +25,10 @@ class Search {
       this.searchBar.init.bind(this.searchBar, this.searchInput)
     );
 
-    this.searchInput.addEventListener(
-      'blur',
-      this.searchBar.hideRecomBox.bind(this.searchBar)
-    );
+    this.searchInput.addEventListener('blur', this.blurHandler.bind(this));
   }
 
-  clickHandler = (e) => {
+  clickHandler(e) {
     e.preventDefault();
     const target = e.target;
 
@@ -48,7 +45,21 @@ class Search {
       default:
         return;
     }
-  };
+  }
+
+  blurHandler({ relatedTarget }) {
+    if (!relatedTarget) {
+      this.searchBar.hideRecomBox();
+      return;
+    }
+    switch (relatedTarget.dataset.recent) {
+      case 'deleteAll':
+        this.searchBar.deleteRecentKeyword();
+        break;
+      default:
+        this.searchBar.hideRecomBox();
+    }
+  }
 }
 
 export { Search };

--- a/public/js/header/search/searchBar.js
+++ b/public/js/header/search/searchBar.js
@@ -45,7 +45,7 @@ class SearchBar {
   }
 
   isValue(keyword) {
-    return keyword ? true : false;
+    return !!keyword;
   }
 
   isResentKeyword() {

--- a/public/js/header/search/searchBar.js
+++ b/public/js/header/search/searchBar.js
@@ -63,6 +63,11 @@ class SearchBar {
     this.hideRecomBox();
   }
 
+  deleteRecentKeyword() {
+    this.storage.deleteStorage();
+    this.hideRecomBox();
+  }
+
   renderKeyword(keywords) {
     const keywordBox = this.recomBox.querySelector('.search_words');
     keywordBox.innerHTML = resentKeywordTemp(keywords);

--- a/public/js/header/search/searchBar.js
+++ b/public/js/header/search/searchBar.js
@@ -4,7 +4,9 @@ import { resentKeywordTemp } from './searchTemplate.js';
 class SearchBar {
   constructor() {
     this.recomBox = document.querySelector('.search-form--recom');
+    this.modeBtn = this.recomBox.querySelector('.recent_mode_btn');
     this.storage = new SearchStorage();
+    this.recentMode = true;
   }
 
   init(input) {
@@ -54,10 +56,8 @@ class SearchBar {
 
   searchKeyword(input) {
     const keyword = input.value;
-    if (keyword === '') {
-      return;
-    }
-    this.storage.addResentSearch(keyword);
+    if (keyword === '') return;
+    if (this.recentMode) this.storage.addResentSearch(keyword);
     input.value = '';
     input.blur();
     this.hideRecomBox();
@@ -66,6 +66,31 @@ class SearchBar {
   deleteRecentKeyword() {
     this.storage.deleteStorage();
     this.hideRecomBox();
+  }
+
+  changeRecentMode(modeBtn, input) {
+    const mode = modeBtn.dataset.mode;
+    mode === 'off' ? (this.recentMode = false) : (this.recentMode = true);
+    this.renderModeTypeView();
+    input.focus();
+  }
+
+  renderModeTypeView() {
+    const searchWords = this.recomBox.querySelector('.search_words');
+    const resentTtl = this.recomBox.querySelector('.resent_ttl');
+
+    if (this.recentMode) {
+      searchWords.style.display = 'block';
+      resentTtl.innerText = '최근 검색어';
+      this.modeBtn.innerText = '최근검색어끄기';
+      this.modeBtn.setAttribute('data-mode', 'off');
+      return;
+    }
+
+    searchWords.style.display = 'none';
+    resentTtl.innerText = '최근 검색어 저장 기능이 꺼져있습니다.';
+    this.modeBtn.innerText = '최근검색어켜기';
+    this.modeBtn.setAttribute('data-mode', 'on');
   }
 
   renderKeyword(keywords) {

--- a/public/js/header/search/searchBar.js
+++ b/public/js/header/search/searchBar.js
@@ -1,22 +1,42 @@
+import { AutoCompleteController } from './autoCompleteController.js';
 import { SearchStorage } from './searchStorage.js';
 import { resentKeywordTemp } from './searchTemplate.js';
 
 class SearchBar {
   constructor() {
     this.recomBox = document.querySelector('.search-form--recom');
+    this.keywordBox = this.recomBox.querySelector('.search_words');
     this.modeBtn = this.recomBox.querySelector('.recent_mode_btn');
     this.storage = new SearchStorage();
+    this.autoComplete = new AutoCompleteController();
     this.recentMode = true;
+    this.firstInput = true;
   }
 
   init(input) {
     const keyword = input.value;
     if (this.isValue(keyword)) {
-      this.hideResentBox();
+      this.getAutoCompleteKeyword(input);
+      this.firstInput = false;
       return;
     }
-
+    this.firstInput = true;
     this.showResentResult();
+  }
+
+  getAutoCompleteKeyword(input) {
+    const keyword = input.value;
+    if (this.firstInput) {
+      this.keywordBox.innerText = '';
+    }
+    this.firstInput = !keyword;
+    this.autoComplete.getRecomKeyword(keyword, this.renderKeyword.bind(this));
+    this.hideResentBox();
+    this.showRecomBox();
+    if (!this.isValue(keyword)) {
+      this.init(input);
+      return;
+    }
   }
 
   showResentResult() {
@@ -25,9 +45,10 @@ class SearchBar {
       this.hideRecomBox();
       return;
     }
-    this.renderKeyword(resentKeywordList);
-    this.showRecomBox();
     this.showResentBox();
+    const keywordHtml = resentKeywordTemp(resentKeywordList);
+    this.renderKeyword(keywordHtml);
+    this.showRecomBox();
   }
 
   showRecomBox() {
@@ -76,26 +97,24 @@ class SearchBar {
   }
 
   renderModeTypeView() {
-    const searchWords = this.recomBox.querySelector('.search_words');
     const resentTtl = this.recomBox.querySelector('.resent_ttl');
 
     if (this.recentMode) {
-      searchWords.style.display = 'block';
+      this.keywordBox.style.display = 'block';
       resentTtl.innerText = '최근 검색어';
       this.modeBtn.innerText = '최근검색어끄기';
       this.modeBtn.setAttribute('data-mode', 'off');
       return;
     }
 
-    searchWords.style.display = 'none';
+    this.keywordBox.style.display = 'none';
     resentTtl.innerText = '최근 검색어 저장 기능이 꺼져있습니다.';
     this.modeBtn.innerText = '최근검색어켜기';
     this.modeBtn.setAttribute('data-mode', 'on');
   }
 
-  renderKeyword(keywords) {
-    const keywordBox = this.recomBox.querySelector('.search_words');
-    keywordBox.innerHTML = resentKeywordTemp(keywords);
+  renderKeyword(html) {
+    this.keywordBox.innerHTML = html;
   }
 }
 

--- a/public/js/header/search/searchStorage.js
+++ b/public/js/header/search/searchStorage.js
@@ -12,6 +12,7 @@ class SearchStorage {
   }
 
   addResentSearch(keyword) {
+    if (this.resentSearch.includes(keyword)) return;
     this.resentSearch.push(keyword);
     this.setStorage();
   }

--- a/public/js/header/search/searchStorage.js
+++ b/public/js/header/search/searchStorage.js
@@ -26,6 +26,11 @@ class SearchStorage {
       this.resentSearch = currentStorage;
     }
   }
+
+  deleteStorage() {
+    this.resentSearch = [];
+    this.storage.removeItem(this.STORAGE_NAME);
+  }
 }
 
 export { SearchStorage };

--- a/public/js/header/search/searchStorage.js
+++ b/public/js/header/search/searchStorage.js
@@ -4,7 +4,7 @@ class SearchStorage {
     this.resentSearch = [];
     this.storage = localStorage;
 
-    this.getStorage();
+    this.loadStorage();
   }
 
   getResentSearch() {
@@ -20,7 +20,7 @@ class SearchStorage {
     this.storage.setItem(this.STORAGE_NAME, JSON.stringify(this.resentSearch));
   }
 
-  getStorage() {
+  loadStorage() {
     const currentStorage = JSON.parse(this.storage.getItem(this.STORAGE_NAME));
     if (currentStorage) {
       this.resentSearch = currentStorage;

--- a/public/js/header/search/searchTemplate.js
+++ b/public/js/header/search/searchTemplate.js
@@ -10,10 +10,23 @@ const categoryTemp = (categorys) => {
 const resentKeywordTemp = (keywords) => {
   const html = keywords
     .map((keyword) => {
-      return `<a href="#!">${keyword}</a>`;
+      return `<a href="#!" data-blur="keyword">${keyword}</a>`;
     })
     .join('');
   return html;
 };
 
-export { categoryTemp, resentKeywordTemp };
+const autoCompleteKeywordTemp = (value, keywords) => {
+  const html = keywords
+    .map((keyword) => {
+      const keywordValue = keyword.value;
+      return `<a href="#!" d안ata-blur="keyword">${keywordValue.replace(
+        value,
+        `<strong>${value}</strong>`
+      )}</a>`;
+    })
+    .join('');
+  return html;
+};
+
+export { categoryTemp, resentKeywordTemp, autoCompleteKeywordTemp };

--- a/public/js/util/util.js
+++ b/public/js/util/util.js
@@ -1,5 +1,5 @@
-export function getData(path) {
-  const data = fetch(`http://localhost:3000/${path}`);
+export function getData(URL) {
+  const data = fetch(URL);
   return data.then((response) => response.json());
 }
 

--- a/public/stylesheet/css/style.css
+++ b/public/stylesheet/css/style.css
@@ -321,20 +321,20 @@
   border-width: 1px;
   border-color: #ddd;
   border-style: solid;
+  border-bottom: none;
   background-color: #fff;
+  box-shadow: 0 4px 5px rgba(0, 0, 0, 0.3);
 }
 .search-form--input-box .search-form--recom .resent_ttl {
   display: none;
   margin: 0 10px;
   padding: 15px 0 10px;
-  border-width: 1px;
-  border-color: #ddd;
-  border-bottom-style: solid;
   font-weight: 700;
 }
 .search-form--input-box .search-form--recom .search_words {
   height: 150px;
-  padding: 10px;
+  margin: 0 10px;
+  padding: 10px 0;
   overflow-y: scroll;
 }
 .search-form--input-box .search-form--recom .search_words a {
@@ -354,7 +354,6 @@
   border-style: solid;
   padding: 10px;
   background-color: #f5f5f5;
-  box-shadow: 0 4px 5px rgba(0, 0, 0, 0.3);
 }
 .search-form--input-box .search-form--recom .recent_controll button {
   color: #888;
@@ -364,6 +363,11 @@
 }
 .search-form--input-box .search-form--recom.resent a:hover {
   color: #4285f4;
+}
+.search-form--input-box .search-form--recom.resent .search_words {
+  border-width: 1px;
+  border-color: #ddd;
+  border-top-style: solid;
 }
 .search-form--input-box .search-form--recom.resent .recent_controll {
   display: flex;

--- a/public/stylesheet/sass/style.scss
+++ b/public/stylesheet/sass/style.scss
@@ -334,20 +334,23 @@
     .search-form--recom {
       display: none;
       @include borderSolid(1px, #ddd, all);
+      border-bottom: none;
       background-color: $white;
       @extend %fontSize12;
+      box-shadow: 0 4px 5px rgba(0, 0, 0, 0.3);
 
       .resent_ttl {
         display: none;
         margin: 0 10px;
         padding: 15px 0 10px;
-        @include borderSolid(1px, #ddd, bottom);
+
         font-weight: 700;
       }
 
       .search_words {
         height: 150px;
-        padding: 10px;
+        margin: 0 10px;
+        padding: 10px 0;
         overflow-y: scroll;
 
         a {
@@ -369,7 +372,6 @@
         @include borderSolid(1px, #ddd, all);
         padding: 10px;
         background-color: #f5f5f5;
-        box-shadow: 0 4px 5px rgba(0, 0, 0, 0.3);
 
         button {
           color: #888;
@@ -383,6 +385,10 @@
       &.resent {
         a:hover {
           color: $point-color;
+        }
+
+        .search_words {
+          @include borderSolid(1px, #ddd, top);
         }
 
         .recent_controll {


### PR DESCRIPTION
# fe-shopping

- 최근검색어  
    - [x] 전체삭제
    - [x] 최근검색어 저장기능 on, off
    - [x] 중복저장 안되게 수정

- 자동완성 ( 아마존 api 사용)  
    - [x] 500ms 이상 글자를 입력하지 않고 머물러 있을때 데이터가져오기
    - [x] 하이라이트 표시

- 미구현
    - [ ] 방향키 이동 이벤트
    - [ ] MV*
    - [ ] 메가드롭


최근검색어와 자동완성검색어 두가지 모두 `.search_words` 태그 안에서  만들어지는데  
입력이 될때 최근검색어 내역이 보이는 문제를 해결하고 싶은데 잘 안되서 시간을 좀 끌었던것 같습니다..😅
입력이 될 때 검색어가 생성되는 부모 `.search_words` 안을 지워주었는데, 입력 될 때마다 지웠다가 `자동검색어` 응답이 보여지기 때문에  
이상해보여서 constructor에 `this.firstInput` 프로퍼티를 주어서 해결하였습니다.

하이라이트 표시 하는 부분을 `아잎` 까지만 입력해도 결과가 나오게 하고싶었는데 쉽지않네요...😭
![이미지](https://user-images.githubusercontent.com/68211156/160050940-dd6b74e7-fdc4-4948-90e0-74fb42b986f3.png)
