### PR TITLE
[옐로우]Step4: Controller가 View는 알되 View 내부는 모르게 하자..

### DIFF
--- a/static/js/searchForm/autoComplete/AutoCompleteController.js
+++ b/static/js/searchForm/autoComplete/AutoCompleteController.js
@@ -4,8 +4,6 @@ export default class AutoCompleteController {
   constructor({ model, view }) {
     this.model = model;
     this.view = view;
-    this.autoCompleteEl = view.autoCompleteEl;
-    this.listEl = view.listEl;
   }
 
   init() {
@@ -14,7 +12,6 @@ export default class AutoCompleteController {
 
   bindMethods() {
     this.view.bound.requestAutoCompleteWords = this.requestAutoCompleteWords.bind(this);
-    this.view.bound.clearAutoComplete = this.clearAutoComplete.bind(this);
   }
 
   async requestAutoCompleteWords(category, inputValue) {
@@ -25,9 +22,5 @@ export default class AutoCompleteController {
     );
     this.model.setAutoCompleteWords(words);
     return this.model.getAutoCompleteWords();
-  }
-
-  clearAutoComplete() {
-    this.listEl.innerHTML = "";
   }
 }

--- a/static/js/searchForm/autoComplete/AutoCompleteView.js
+++ b/static/js/searchForm/autoComplete/AutoCompleteView.js
@@ -33,4 +33,8 @@ export default class AutoCompleteView {
   hideAutoComplete() {
     this.autoCompleteEl.classList.replace(this.className.show, this.className.hidden);
   }
+
+  clearAutoComplete() {
+    this.listEl.innerHTML = "";
+  }
 }

--- a/static/js/searchForm/category/CategoryController.js
+++ b/static/js/searchForm/category/CategoryController.js
@@ -2,8 +2,6 @@ export default class CategoryController {
   constructor({ model, view }) {
     this.model = model;
     this.view = view;
-    this.currentEl = view.currentEl;
-    this.listEl = view.listEl;
   }
 
   init() {
@@ -20,23 +18,11 @@ export default class CategoryController {
   }
 
   bindMethods() {
-    this.view.bound.hideListFromEventTarget = this.hideListFromEventTarget.bind(this);
     this.view.bound.selectCategory = this.selectCategory.bind(this);
   }
 
-  hideListFromEventTarget(eventTarget) {
-    if (
-      eventTarget === this.currentEl ||
-      eventTarget.parentNode === this.listEl ||
-      this.listEl.classList.contains(this.view.hidden)
-    )
-      return;
-
-    this.view.hideList();
-  }
-
   selectCategory(eventTarget) {
-    const currentCategory = this.currentEl.textContent;
+    const currentCategory = this.model.getCurrentCategory();
     const selectedCategory = eventTarget.dataset.category;
 
     if (!selectedCategory) return;

--- a/static/js/searchForm/category/CategoryView.js
+++ b/static/js/searchForm/category/CategoryView.js
@@ -16,7 +16,7 @@ export default class CategoryView {
     this.listEl.addEventListener("click", (event) => this.bound.selectCategory(event.target));
     dom
       .select("body")
-      .addEventListener("click", (event) => this.bound.hideListFromEventTarget(event.target));
+      .addEventListener("click", (event) => this.hideListFromEventTarget(event.target));
   }
 
   createItem(category) {
@@ -41,6 +41,17 @@ export default class CategoryView {
 
   hideList() {
     this.listEl.classList.replace(this.className.show, this.className.hidden);
+  }
+
+  hideListFromEventTarget(eventTarget) {
+    if (
+      eventTarget === this.currentEl ||
+      eventTarget.parentNode === this.listEl ||
+      this.listEl.classList.contains(this.className.hidden)
+    )
+      return;
+
+    this.hideList();
   }
 
   toggleList() {

--- a/static/js/searchForm/history/HistoryController.js
+++ b/static/js/searchForm/history/HistoryController.js
@@ -2,7 +2,6 @@ export default class HistoryController {
   constructor({ model, view }) {
     this.model = model;
     this.view = view;
-    this.historyEl = view.historyEl;
   }
 
   init() {

--- a/static/js/searchForm/input/InputController.js
+++ b/static/js/searchForm/input/InputController.js
@@ -4,9 +4,6 @@ export default class InputController {
     this.inputView = view;
     this.historyView = historyView;
     this.autoCompleteView = autoCompleteView;
-
-    this.inputEl = view.inputEl;
-    this.resultEl = view.resultEl;
     this.autoCompleteTimerId;
   }
 
@@ -26,21 +23,17 @@ export default class InputController {
   resetResult() {
     this.historyView.showHistory();
     this.autoCompleteView.hideAutoComplete();
-    this.autoCompleteView.bound.clearAutoComplete();
+    this.autoCompleteView.clearAutoComplete();
   }
   isHistoryEmpty() {
     return this.model.getHistory().length === 0;
-  }
-
-  getInputValue() {
-    return this.inputEl.value;
   }
 
   submitInputValue(event) {
     event.preventDefault();
 
     this.clearAutoCompleteTimer();
-    const inputValue = this.getInputValue();
+    const inputValue = this.inputView.getInputValue();
     if (!inputValue) return;
 
     this.model.setHistory(inputValue);
@@ -48,20 +41,20 @@ export default class InputController {
     this.resetResult();
 
     this.inputView.clear();
-    this.inputEl.blur();
+    this.inputView.blur();
   }
 
-  setAutoCompleteTimer(event) {
+  setAutoCompleteTimer(ms) {
     this.clearAutoCompleteTimer();
 
     this.autoCompleteTimerId = setTimeout(() => {
       const category = this.model.getCurrentCategory();
-      const inputValue = event.target.value;
+      const inputValue = this.inputView.getInputValue();
       this.autoCompleteView.renderAutoComplete(category, inputValue);
 
       this.inputView.showResult();
       this.historyView.hideHistory();
-    }, 500);
+    }, ms);
   }
 
   clearAutoCompleteTimer() {

--- a/static/js/searchForm/input/InputView.js
+++ b/static/js/searchForm/input/InputView.js
@@ -20,7 +20,7 @@ export default class InputView {
         this.bound.isHistoryEmpty() && this.hideResult();
         return;
       }
-      this.bound.setAutoCompleteTimer(event);
+      this.bound.setAutoCompleteTimer(500);
     });
 
     this.inputEl.addEventListener("focus", () => {
@@ -36,11 +36,19 @@ export default class InputView {
     this.inputEl.value = "";
   }
 
+  blur() {
+    this.inputEl.blur();
+  }
+
   showResult() {
     this.resultEl.classList.replace(this.className.hidden, this.className.show);
   }
 
   hideResult() {
     this.resultEl.classList.replace(this.className.show, this.className.hidden);
+  }
+
+  getInputValue() {
+    return this.inputEl.value;
   }
 }


### PR DESCRIPTION
이전 PR에서 남세님의 피드백을 받아 개선해보았습니다.

Controller는 View에게 메소드를 호출해 요청만 하고, view의 프로퍼티를 직접 조작하지 않는다.
-> Controller에서 View의 프로퍼티를 참조했던 것들이 없어짐.
-> Controller의 내용이 주로 view와 model의 메소드를 호출하는 것들로 채워져 가독성이 좋아진 것 같음.